### PR TITLE
Updates the METHOD_POST usage.

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -5,17 +5,13 @@ namespace Omnipay\IcepayPayments\Message;
 use DateTimeInterface;
 use Omnipay\Common\Message\AbstractRequest as OmnipayAbstractRequest;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class AbstractRequest.
  */
 abstract class AbstractRequest extends OmnipayAbstractRequest
 {
-    /**
-     * @var string
-     */
-    public const METHOD_POST = 'POST';
-
     /**
      * @var string
      */
@@ -47,7 +43,7 @@ abstract class AbstractRequest extends OmnipayAbstractRequest
         $headers = $this->getAuthenticationHeaders($securityHash);
         $body = null;
 
-        if ($method === self::METHOD_POST) {
+        if ($method === Request::METHOD_POST) {
             $headers['Content-Type'] = 'application/json';
             $body = json_encode($data);
         }

--- a/src/Message/CreateTransactionRequest.php
+++ b/src/Message/CreateTransactionRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\IcepayPayments\Message;
 
 use Omnipay\Common\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The request for creating a transaction at Icepay.
@@ -59,7 +60,7 @@ class CreateTransactionRequest extends AbstractRequest
     public function sendData($data): ResponseInterface
     {
         $this->sendRequest(
-            self::METHOD_POST,
+            Request::METHOD_POST,
             '/contract/transaction',
             $data
         );

--- a/src/Message/RefundRequest.php
+++ b/src/Message/RefundRequest.php
@@ -4,6 +4,7 @@ namespace Omnipay\IcepayPayments\Message;
 
 use Omnipay\Common\Exception\InvalidRequestException;
 use Omnipay\Common\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The request for refunding at Icepay.
@@ -38,7 +39,7 @@ class RefundRequest extends AbstractRequest
         }
 
         $this->sendRequest(
-            self::METHOD_POST,
+            Request::METHOD_POST,
             sprintf(
                 '/transaction/%s/refund',
                 $this->getTransactionReference()

--- a/src/Message/TransactionStatusRequest.php
+++ b/src/Message/TransactionStatusRequest.php
@@ -3,6 +3,7 @@
 namespace Omnipay\IcepayPayments\Message;
 
 use Omnipay\Common\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * The request for getting the transaction status at Icepay.
@@ -31,7 +32,7 @@ class TransactionStatusRequest extends AbstractRequest
     public function sendData($data): ResponseInterface
     {
         $this->sendRequest(
-            self::METHOD_POST,
+            Request::METHOD_POST,
             sprintf(
                 '/transaction/%s',
                 $this->getTransactionReference()

--- a/tests/Message/CreateTransactionRequestTest.php
+++ b/tests/Message/CreateTransactionRequestTest.php
@@ -5,6 +5,7 @@ namespace Omnipay\IcepayPayments\Message;
 use DateTime;
 use GuzzleHttp\Psr7\Request;
 use Omnipay\IcepayPayments\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 /**
  * Class CreateTransactionRequestTest.
@@ -126,7 +127,7 @@ class CreateTransactionRequestTest extends AbstractTestCase
         $this->assertInstanceOf(CreateTransactionResponse::class, $response);
 
         $expectedRequest = new Request(
-            AbstractRequest::METHOD_POST,
+            SymfonyRequest::METHOD_POST,
             'https://www.superbrave.nl/contract/transaction'
         );
 

--- a/tests/Message/RefundRequestTest.php
+++ b/tests/Message/RefundRequestTest.php
@@ -4,8 +4,8 @@ namespace Omnipay\IcepayPayments\Message;
 
 use GuzzleHttp\Psr7\Request;
 use Omnipay\Common\Exception\InvalidRequestException;
-use Omnipay\Common\Http\Client;
 use Omnipay\IcepayPayments\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 class RefundRequestTest extends AbstractTestCase
 {
@@ -63,7 +63,7 @@ class RefundRequestTest extends AbstractTestCase
         $this->assertInstanceOf(RefundResponse::class, $response);
 
         $expectedRequest = new Request(
-            AbstractRequest::METHOD_POST,
+            SymfonyRequest::METHOD_POST,
             'https://www.superbrave.nl/transaction/1M-MR-M33533K5-L00K-47-M3/refund'
         );
 

--- a/tests/Message/TransactionStatusRequestTest.php
+++ b/tests/Message/TransactionStatusRequestTest.php
@@ -5,6 +5,7 @@ namespace Omnipay\IcepayPayments\Message;
 use DateTime;
 use GuzzleHttp\Psr7\Request;
 use Omnipay\IcepayPayments\AbstractTestCase;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 /**
  * Class TransactionStatusRequestTest.
@@ -66,7 +67,7 @@ class TransactionStatusRequestTest extends AbstractTestCase
         $this->assertInstanceOf(TransactionStatusResponse::class, $response);
 
         $expectedRequest = new Request(
-            AbstractRequest::METHOD_POST,
+            SymfonyRequest::METHOD_POST,
             'https://www.superbrave.nl/transaction/e7ca29c8-f1f4-4a4c-a968-0f9667d0519d'
         );
 


### PR DESCRIPTION
Removed the AbstractRequest::METHOD_POST constant for the Symfony HttpFoundation Request::METHOD_POST constant.