### PR TITLE
Added the Category for Consumer and DeliveryConsumer in the Fulfillment section of the request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "config": {
         "bin-dir": "bin"
     },
+    "scripts": {
+        "test": "phpunit"
+    },
     "require": {
         "php": "^7.2.9",
         "ext-json": "*",

--- a/src/Message/CreateTransactionRequest.php
+++ b/src/Message/CreateTransactionRequest.php
@@ -44,6 +44,12 @@ class CreateTransactionRequest extends AbstractRequest
                 'IssuerCode' => $this->getIssuerCode(),
                 'AmountInCents' => $this->getAmountInteger(),
                 'CurrencyCode' => $this->getCurrencyCode(),
+                'Consumer' => [
+                    'Category' => 'Person',
+                ],
+                'DeliveryConsumer' => [
+                    'Category' => 'Person',
+                ],
                 'Timestamp' => $this->getTimestamp()->format(self::TIMESTAMP_FORMAT),
                 'LanguageCode' => $this->getLanguageCode(),
                 'CountryCode' => $this->getCountryCode(),

--- a/tests/Message/CreateTransactionRequestTest.php
+++ b/tests/Message/CreateTransactionRequestTest.php
@@ -78,6 +78,12 @@ class CreateTransactionRequestTest extends AbstractTestCase
                 'IssuerCode' => 'ABNAMRO',
                 'AmountInCents' => 1337,
                 'CurrencyCode' => 'EUR',
+                'Consumer' => [
+                    'Category' => 'Person',
+                ],
+                'DeliveryConsumer' => [
+                    'Category' => 'Person',
+                ],
                 'Timestamp' => '2019-03-09T12:00:00Z',
                 'LanguageCode' => 'nl',
                 'CountryCode' => 'NL',


### PR DESCRIPTION
According to the documentation these fields are only required if we add the Consumer and DeliveryConsumer values. If we neglect them the customer/user has to specify the extra information during the payment.

https://documentation.icepay.com/api/#operation/Transaction